### PR TITLE
fix font-size for footer, add box-shadow variable, fix not-found styles

### DIFF
--- a/src/components/Footer/Footer.scss
+++ b/src/components/Footer/Footer.scss
@@ -9,6 +9,7 @@
     padding: 2.5rem 0;
     @include tablet {
       padding-top: 9.6875rem;
+      font-size: .75rem;
     }
     @include desktop {
         padding-top: 5.9375rem;

--- a/src/pages/NotFoundPage/NotFoundPage.scss
+++ b/src/pages/NotFoundPage/NotFoundPage.scss
@@ -1,15 +1,21 @@
-.error{
-    background-color: white;
-    padding: 2rem;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 1.5rem;
+@use "../../styles/partials/mixins" as *;
+@use "../../styles/partials/variables" as *;
 
-    &__home-button{
-        text-decoration: none;
-        color: rgb(46,102,229);
-        font-weight: 600;
-        cursor: pointer;
-    }
+
+.error {
+  background-color: $primary-white;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+  border-radius: 3px;
+  box-shadow: $box-shadow;
+
+  &__home-button {
+    text-decoration: none;
+    color: rgb(46, 102, 229);
+    font-weight: 600;
+    cursor: pointer;
+  }
 }

--- a/src/styles/partials/_variables.scss
+++ b/src/styles/partials/_variables.scss
@@ -19,3 +19,6 @@ $bg-light-grey: #f7f8f9;
 // Supporting Colors
 $supporting-green: #158463;
 $supporting-red: #c94515;
+
+// box-shadow
+$box-shadow: 0 2px 5px 0 rgba(19, 24, 44, 0.1);


### PR DESCRIPTION
1. changed font-size for footer text for tablet and desktop breakpoints, 
2. added box-shadow variable, 
3. fix not-found styles: added box-shadow and border-radius